### PR TITLE
Fix test failures

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -28,4 +28,5 @@ require 'test/unit/rr'
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'fluent/test'
+require 'fluent/process'
 require 'fluent/plugin/out_kinesis-aggregation'

--- a/test/plugin/test_out_kinesis-aggregation.rb
+++ b/test/plugin/test_out_kinesis-aggregation.rb
@@ -34,7 +34,7 @@ class KinesisOutputTest < Test::Unit::TestCase
 
   def create_mock_client
     client = mock(Object.new)
-    mock(Aws::Kinesis::Client).new({}) { client }
+    mock(Aws::Kinesis::Client).new(anything) { client }
     return client
   end
 
@@ -209,7 +209,7 @@ class KinesisOutputTest < Test::Unit::TestCase
       Time.parse("2011-01-02 13:14:15 UTC").to_i)
     client = dont_allow(Object.new)
     client.put_record
-    mock(Aws::Kinesis::Client).new({}) { client }
+    mock(Aws::Kinesis::Client).new(anything) { client }
 
     d.run
   end


### PR DESCRIPTION
- add a new require to test/helper.rb for fluentd >= 0.12.21
- for rr >= 1.2 a wildcard is needed for aws kinesis client mocks