### PR TITLE
OBSHELP-2411 use aws-sdk-kinesis gem instead of aws-sdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: ruby
 rvm:
   - 2.4
   - 2.3
-  - 2.2
-  - 2.1
 
 os:
   - linux

--- a/fluent-plugin-kinesis-aggregation.gemspec
+++ b/fluent-plugin-kinesis-aggregation.gemspec
@@ -35,6 +35,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "test-unit-rr", "~> 1.0"
 
   spec.add_dependency "fluentd", [">= 0.14.15", "< 2"]
-  spec.add_dependency "aws-sdk", ">= 2.0.12", "< 4.0"
+  spec.add_dependency "aws-sdk-kinesis", "~> 1", "!= 1.4", "!= 1.5", "!= 1.14"
   spec.add_dependency "google-protobuf", "~> 3.0"
 end

--- a/fluent-plugin-kinesis-aggregation.gemspec
+++ b/fluent-plugin-kinesis-aggregation.gemspec
@@ -28,13 +28,14 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = '>= 2.1'
+  spec.required_ruby_version = '>= 2.3'
 
-  spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "test-unit-rr", "~> 1.0"
+  spec.add_development_dependency "bundler", ">= 1.10"
+  spec.add_development_dependency "rake", ">= 10.0"
+  spec.add_development_dependency "test-unit", ">= 3.0.8"
+  spec.add_development_dependency "test-unit-rr", ">= 1.0.3"
 
-  spec.add_dependency "fluentd", [">= 0.14.15", "< 2"]
+  spec.add_dependency "fluentd", [">= 0.14.22", "< 2"]
   spec.add_dependency "aws-sdk-kinesis", "~> 1", "!= 1.4", "!= 1.5", "!= 1.14"
-  spec.add_dependency "google-protobuf", "~> 3.0"
+  spec.add_dependency "google-protobuf", "~> 3"
 end

--- a/lib/fluent/plugin/out_kinesis-aggregation.rb
+++ b/lib/fluent/plugin/out_kinesis-aggregation.rb
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-require 'aws-sdk'
+require 'aws-sdk-kinesis'
 require 'yajl'
 require 'logger'
 require 'securerandom'


### PR DESCRIPTION
This avoids installing the entire aws-sdk (~220 gems currently); saves _several minutes_ of installation time.