### PR TITLE
ITOPSENG-635 google-protobuf 3.12.x requires Ruby >=2.5

### DIFF
--- a/fluent-plugin-kinesis-aggregation.gemspec
+++ b/fluent-plugin-kinesis-aggregation.gemspec
@@ -37,5 +37,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "fluentd", [">= 0.14.22", "< 2"]
   spec.add_dependency "aws-sdk-kinesis", "~> 1", "!= 1.4", "!= 1.5", "!= 1.14"
-  spec.add_dependency "google-protobuf", "~> 3"
+  spec.add_dependency "google-protobuf", "~> 3.11.0"
 end


### PR DESCRIPTION
td-agent v3.7.1 ships Ruby 2.4.10 embedded, so pin google-protobuf to 3.11.x.

Ref:
* https://github.com/protocolbuffers/protobuf/issues/7518
* https://github.com/awslabs/aws-fluent-plugin-kinesis/pull/199