### PR TITLE
Update dependencies (aws-sdk-kinesis and google-protobuf)

### DIFF
--- a/fluent-plugin-kinesis-aggregation.gemspec
+++ b/fluent-plugin-kinesis-aggregation.gemspec
@@ -36,6 +36,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "test-unit-rr", ">= 1.0.3"
 
   spec.add_dependency "fluentd", [">= 0.14.22", "< 2"]
-  spec.add_dependency "aws-sdk-kinesis", "~> 1", "!= 1.4", "!= 1.5", "!= 1.14"
+  spec.add_dependency "aws-sdk-kinesis", "~> 1", "!= 1.4", "!= 1.5", "!= 1.14", "!= 1.24"
   spec.add_dependency "google-protobuf", "~> 3.11.0"
 end

--- a/fluent-plugin-kinesis-aggregation.gemspec
+++ b/fluent-plugin-kinesis-aggregation.gemspec
@@ -37,5 +37,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "fluentd", [">= 0.14.22", "< 2"]
   spec.add_dependency "aws-sdk-kinesis", "~> 1", "!= 1.4", "!= 1.5", "!= 1.14", "!= 1.24"
-  spec.add_dependency "google-protobuf", "~> 3.11.0"
+  spec.add_dependency "google-protobuf", "~> 3", "< 3.12"
 end


### PR DESCRIPTION
### aws-sdk-kinesis

The 1.24 release of aws-sdk-kinesis is missing a dependency from a newer version of the aws-sdk-core gem:

```
`require': cannot load such file -- aws-sdk-core/plugins/http_checksum.rb (LoadError)
```

More details are in https://github.com/aws/aws-sdk-ruby/issues/2327; 1.24 has been yanked and 1.24.1 has been released with the fix, but just in case 1.24 has already been installed/cached anywhere, add it to the list of excluded versions.

### google-protobuf

Previously, we pinned google-protobuf to 3.11.x (#6) because 3.12 required Ruby >=2.5 (and td-agent ships with Ruby 2.4 embedded). google-protobuf 3.12.1 restores support for Ruby 2.3 and 2.4, so we can relax our pinning for this dependency a bit by requiring versions greater than 3.12.