### PR TITLE
ITPLT-868 update dependencies for td-agent v4 compatibilty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: ruby
 
 rvm:
-  - 2.4
-  - 2.3
+  - 2.7
 
 os:
   - linux

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ This plugin is available as the `fluent-plugin-kinesis-aggregation` gem from Rub
 
 Or, if using td-agent:
 
-    fluent-gem install fluent-plugin-kinesis-aggregation
+    td-agent-gem install fluent-plugin-kinesis-aggregation
 
 To install from the source:
 
@@ -74,8 +74,10 @@ specify the library path via RUBYLIB:
 
 ## Dependencies
 
- * Ruby 2.1+
- * Fluentd 0.14.15+ (if you need 0.10 or 0.12 support, use the fluentd-v0.12 branch or version 0.2.x on rubygems)
+ * Ruby 2.7+
+ * Fluentd 1+
+
+If you need td-agent v3 support, use version 0.3.x on rubygems. If you need td-agent v2 support (or fluentd 0.10 or 0.12 support), use the fluentd-v0.12 branch or version 0.2.x on rubygems.
 
 ## Basic Usage
 

--- a/fluent-plugin-kinesis-aggregation.gemspec
+++ b/fluent-plugin-kinesis-aggregation.gemspec
@@ -30,12 +30,12 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = '>= 2.7'
 
-  spec.add_development_dependency "bundler", ">= 1.10"
-  spec.add_development_dependency "rake", ">= 10.0"
-  spec.add_development_dependency "test-unit", ">= 3.0.8"
-  spec.add_development_dependency "test-unit-rr", ">= 1.0.3"
+  spec.add_development_dependency "bundler", "~> 2"
+  spec.add_development_dependency "rake", "~> 13"
+  spec.add_development_dependency "test-unit", "~> 3"
+  spec.add_development_dependency "test-unit-rr", "~> 1"
 
   spec.add_dependency "fluentd", ["~> 1", "< 2"]
   spec.add_dependency "aws-sdk-kinesis", "~> 1", "!= 1.4", "!= 1.5", "!= 1.14", "!= 1.24"
-  spec.add_dependency "google-protobuf", "~> 3", "> 3.12"
+  spec.add_dependency "google-protobuf", "~> 3", "!= 3.12.0"
 end

--- a/fluent-plugin-kinesis-aggregation.gemspec
+++ b/fluent-plugin-kinesis-aggregation.gemspec
@@ -28,14 +28,14 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = '>= 2.3'
+  spec.required_ruby_version = '>= 2.7'
 
   spec.add_development_dependency "bundler", ">= 1.10"
   spec.add_development_dependency "rake", ">= 10.0"
   spec.add_development_dependency "test-unit", ">= 3.0.8"
   spec.add_development_dependency "test-unit-rr", ">= 1.0.3"
 
-  spec.add_dependency "fluentd", [">= 0.14.22", "< 2"]
+  spec.add_dependency "fluentd", ["~> 1", "< 2"]
   spec.add_dependency "aws-sdk-kinesis", "~> 1", "!= 1.4", "!= 1.5", "!= 1.14", "!= 1.24"
-  spec.add_dependency "google-protobuf", "~> 3", "< 3.12"
+  spec.add_dependency "google-protobuf", "~> 3", "> 3.12"
 end


### PR DESCRIPTION
td-agent v3 is EOL: https://www.fluentd.org/blog/schedule-for-td-agent-3-eol

td-agent v4 ships with Ruby 2.7 embedded and requires some updated dependencies (notably google-protobuf, which [dropped support for Ruby < 2.5](https://github.com/protocolbuffers/protobuf/pull/9311)), so I'll cut a new minor release after this is merged (0.4.0) to match our semi-semver/matching td-agent version release convention.